### PR TITLE
Fix escaping of ? and \n

### DIFF
--- a/Donations/src/main/res/values-de/strings.xml
+++ b/Donations/src/main/res/values-de/strings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
 	<string name="donations__button_close">Schließen</string>
-	<string name="donations__description">Findest Du diese Anwendung nützlich\?\\\nDann unterstütze die Entwicklung durch eine Spende!</string>
+	<string name="donations__description">Findest Du diese Anwendung nützlich?\nDann unterstütze die Entwicklung durch eine Spende!</string>
 	<string name="donations__google_android_market">Google Play Store</string>
 	<string name="donations__google_android_market_not_supported_title">In-App-Spenden werden nicht unterstützt.</string>
-	<string name="donations__google_android_market_not_supported">In-App-Spenden werden nicht unterstützt. Ist »Google Play Store« korrekt installiert\?</string>
+	<string name="donations__google_android_market_not_supported">In-App-Spenden werden nicht unterstützt. Ist »Google Play Store« korrekt installiert?</string>
 	<string name="donations__google_android_market_description">Google berechnet eine Gebühr von 30%</string>
 	<string name="donations__google_android_market_donate_button">Spende!</string>
-	<string name="donations__google_android_market_text">Wie viel\?</string>
+	<string name="donations__google_android_market_text">Wie viel?</string>
 	<string name="donations__paypal">PayPal</string>
 	<string name="donations__paypal_description">Du kannst die Höhe der Spende auswählen, nach dem du auf den Knopf geklickt hast!</string>
 	<string name="donations__thanks_dialog_title">Danke!</string>


### PR DESCRIPTION
Fix escaping of `?` and `\n` in German translation.
the `?` was unnessecaryly escaped and the `\n` was escaped twice